### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,7 @@ setup(
       'amzsear = amzsear.cli.cli:run',
      ],
   },
+  install_requires=[
+    'lxml==3.8',
+  ],
 )


### PR DESCRIPTION
pip install amzsear does not install lxml requirement unless it is specified in setup.py