### PR TITLE
amzSear v3: Updated selectors, ASIN-based API, product details, reviews, and modern dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 */__pycache__/*
 */__pycache__
+__pycache__/
+.venv/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -13,27 +13,18 @@ $ amzsear 'Harry Potter Books'
 
 
 ```
-    Title                                               Prices             Rating
-0   Harry Potter Paperback Box Set (Books 1-7)          $21.20 - $52.99    *****
-1   Harry Potter and the Sorcerer's Stone               $0.00 - $10.99     *****
-2   Harry Potter And The Chamber Of Secrets             $0.00 - $10.99     *****
-3   Harry Potter And The Goblet Of Fire                 $0.00 - $12.99     *****
-4   Harry Potter and the Prisoner of Azkaban            $0.00 - $10.99     *****
-5   Harry Potter And The Order Of The Phoenix           $0.00 - $12.99     *****
-6   Harry Potter and the Deathly Hallows (Book 7)       $0.00 - $14.99     *****
-7   Harry Potter and the Half-Blood Prince (Book 6)     $0.00 - $12.99     *****
-8   [Sponsored]Hudson James & the Baker Street Legacy   $0.00 - $3.07      -----
-9   [Sponsored]Kids' Travel Guide - London: The fun wa  $8.37 - $10.90     *****
-10  Harry Potter and the Sorcerer's Stone: The Illustr  $9.23 - $39.99     ****
-11  Harry Potter Complete Book Series Special Edition   $64.88 - $81.95    *****
-12  Harry Potter and the Cursed Child, Parts One and T  $3.15 - $12.99     ****
-13  Harry Potter Books Set #1-7 in Collectible Trunk-L  $73.96 - $157.95   ****
-14  Harry Potter Complete Collection 7 Books Set Colle  $146.89 - $163.99  *****
-15  Harry Potter and the Chamber of Secrets: The Illus  $20.51 - $39.99    *****
-16  Harry Potter and the Prisoner of Azkaban: The Illu  $15.92 - $275.00   *****
-17  The Unofficial Harry Potter Spellbook: Wizard Trai  $0.00 - $13.95     ****
-18  [Sponsored]Widdershins – Part One: The Boy with Ab  $0.00 - $0.76      *****
-19  [Sponsored]Missions Accomplished: And some funny b  $0.00 - $3.96      *****
+ASIN        Title                                               Prices             Rating
+B01CUKZNM2  Harry Potter Paperback Box Set (Books 1-7)          $21.20 - $52.99    *****
+B00728DYLA  Harry Potter and the Sorcerer's Stone               $0.00 - $10.99     *****
+B00728DYLY  Harry Potter And The Chamber Of Secrets             $0.00 - $10.99     *****
+B00728E75S  Harry Potter And The Goblet Of Fire                 $0.00 - $12.99     *****
+B00728DYCU  Harry Potter and the Prisoner of Azkaban            $0.00 - $10.99     *****
+B00728E6Z4  Harry Potter And The Order Of The Phoenix           $0.00 - $12.99     *****
+B00728DYPE  Harry Potter and the Deathly Hallows (Book 7)       $0.00 - $14.99     *****
+B00728E6G8  Harry Potter and the Half-Blood Prince (Book 6)     $0.00 - $12.99     *****
+B01LTHVLSC  Harry Potter and the Sorcerer's Stone: The Illustr  $9.23 - $39.99     ****
+B01LTHXA3C  Harry Potter Complete Book Series Special Edition   $64.88 - $81.95    *****
+B01ELVJPJW  Harry Potter and the Cursed Child, Parts One and T  $3.15 - $12.99     ****
 ```
 
 ![Amazon Comparison Shot](amazon_screenshot.png)
@@ -72,20 +63,20 @@ The amzSear CLI allows Amazon search queries to be performed directly from the c
 $ amzsear 'Harry Potter Books'
 ```
 
-However, additional options can be set to select the page number, item number, region or the output format. For example:
+However, additional options can be set to select the page number, item, region or the output format. For example:
 
 ```
-$ amzsear 'Harry Potter' -p 2 -i 35 --output json
+$ amzsear 'Harry Potter' -p 2 -i B00728DYLA --output json
 ```
 
-The above query will display the item at index 35 on page 2 as a JSON object.
+The above query will display the item with ASIN B00728DYLA on page 2 as a JSON object. The `-i` flag accepts both ASIN and numeric index (0-based position).
 
 #### Product Lookup by ASIN
 
 You can also fetch detailed product information directly by ASIN using the `-P/--product` flag:
 
 ```
-$ amzsear -P B00006IFHD -d
+$ amzsear -P B00006IFHD
 ```
 
 ```
@@ -104,6 +95,12 @@ Technical details (21 fields)
 ```
 
 This fetches the product page and extracts detailed information including brand, full title, bullet points, technical specifications, and review statistics. All output formats (short, verbose, json, csv) are supported.
+
+Use `-b/--browser` to open the product page in your default browser:
+
+```
+$ amzsear -P B00006IFHD -b
+```
 
 For more examples and for extended usage information see the [CLI Readme](docs/cli/README.md).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,34 @@ However, additional options can be set to select the page number, item number, r
 $ amzsear 'Harry Potter' -p 2 -i 35 --output json
 ```
 
-The above query will display the item at index 35 on page 2 as a JSON object. For more examples and for extended usage information see the [CLI Readme](docs/cli/README.md).
+The above query will display the item at index 35 on page 2 as a JSON object.
+
+#### Product Lookup by ASIN
+
+You can also fetch detailed product information directly by ASIN using the `-P/--product` flag:
+
+```
+$ amzsear -P B00006IFHD -d
+```
+
+```
+ASIN:   B00006IFHD
+Title:  Sharpie Permanent Markers Set Quick Drying And Fade Resistant Fine ...
+Brand:  Sharpie
+Rating: 4.8/5 (43,116 reviews)
+
+About this item (7 points):
+  1. Fine-tipped, Detailed Marks: Versatile fine tip allows users to make eye-catchin...
+  2. Permanent Ink: Makes a resilient mark on paper, plastic, and metal surfaces
+  3. Quick-Drying: Quick-drying feature ensures writing resilience against water and ...
+  ... and 4 more
+
+Technical details (21 fields)
+```
+
+This fetches the product page and extracts detailed information including brand, full title, bullet points, technical specifications, and review statistics. All output formats (short, verbose, json, csv) are supported.
+
+For more examples and for extended usage information see the [CLI Readme](docs/cli/README.md).
 
 
 #### API
@@ -121,6 +148,7 @@ For a complete explanation of the intricacies of the amzSear core API, see the [
 |----------------------------------------------------------------|-------|-------|
 | Command line Amazon queries                                    | ✓     | ✓     |
 | Command line conversion to CSV or JSON                         |       | ✓     |
+| Product lookup by ASIN with detailed info                      |       | ✓     |
 | Support for US Amazon                                          | ✓     | ✓     |
 | Support across __all__ Amazon regions                          |       | ✓     |
 | Single page API queries                                        | ✓     | ✓     |
@@ -137,6 +165,7 @@ For a complete explanation of the intricacies of the amzSear core API, see the [
 * Dedicated AmzSear class & subclasses
 * Better scraping & extraction to retrieve all data
 * Additional fields - including image_url, subtitle/subtext, rating's count
+* Product lookup by ASIN - fetch detailed product info (brand, specs, bullet points, reviews)
 * Simpler usability and clearer command line interface
 * Multiple command line export formats - CSV, JSON, etc.
 
@@ -151,4 +180,4 @@ A more in depth understanding of the latest features of the CLI can be explored 
 * [Linux-OS.net](http://linux-os.net/amzsear-busca-productos-en-amazon-desde-la-linea-de-comandos/)
 * [MasLinux](http://maslinux.es/buscar-productos-de-amazon-desde-la-linea-de-comandos/)
 
-This library was designed to facilitate the use of amazon search on the command line whilst also providing a utility to easily scrape basic product information from Amazon (for those without access to Amazon's Product API). The developer does, however, append an Amazon Affiliate Tag in order to track usage of this software and to monetize this and other publicly accessible projects. We are a participant in the Amazon Services LLC Associates Program, an affiliate advertising program designed to provide a means for us to earn fees by linking to Amazon.com and affiliated sites.
+This library was designed to facilitate the use of Amazon search on the command line whilst also providing a utility to easily scrape basic product information from Amazon (for those without access to Amazon's Product API).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ amzsear 'Harry Potter Books'
 However, additional options can be set to select the page number, item, region or the output format. For example:
 
 ```
-$ amzsear 'Harry Potter' -p 2 -s B00728DYLA --output json
+$ amzsear 'Harry Potter' -p 2 -s B00728DYLA -j
 ```
 
 The above query will display the item with ASIN B00728DYLA on page 2 as a JSON object. The `-s` flag accepts both ASIN and numeric index (0-based position).
@@ -94,7 +94,7 @@ About this item (7 points):
 Technical details (21 fields)
 ```
 
-This fetches the product page and extracts detailed information including brand, full title, bullet points, technical specifications, and review statistics. All output formats (short, verbose, json, csv) are supported.
+This fetches the product page and extracts detailed information including brand, full title, bullet points, technical specifications, and review statistics. Use `-v` for verbose output or `-j` for JSON format.
 
 Use `-b/--browser` to open the product page in your default browser:
 
@@ -144,7 +144,7 @@ For a complete explanation of the intricacies of the amzSear core API, see the [
 | Feature                                                        | v 1.0 | v 2.0 |
 |----------------------------------------------------------------|-------|-------|
 | Command line Amazon queries                                    | ✓     | ✓     |
-| Command line conversion to CSV or JSON                         |       | ✓     |
+| Command line conversion to JSON                                |       | ✓     |
 | Product lookup by ASIN with detailed info                      |       | ✓     |
 | Support for US Amazon                                          | ✓     | ✓     |
 | Support across __all__ Amazon regions                          |       | ✓     |
@@ -164,7 +164,7 @@ For a complete explanation of the intricacies of the amzSear core API, see the [
 * Additional fields - including image_url, subtitle/subtext, rating's count
 * Product lookup by ASIN - fetch detailed product info (brand, specs, bullet points, reviews)
 * Simpler usability and clearer command line interface
-* Multiple command line export formats - CSV, JSON, etc.
+* JSON export format for programmatic use
 
 A more in depth understanding of the latest features of the CLI can be explored in the [CLI Readme](docs/cli/README.md). A complete breakdown of the core API's extended features can be seen in the core [API docs](docs/core/).
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ $ amzsear 'Harry Potter Books'
 However, additional options can be set to select the page number, item, region or the output format. For example:
 
 ```
-$ amzsear 'Harry Potter' -p 2 -i B00728DYLA --output json
+$ amzsear 'Harry Potter' -p 2 -s B00728DYLA --output json
 ```
 
-The above query will display the item with ASIN B00728DYLA on page 2 as a JSON object. The `-i` flag accepts both ASIN and numeric index (0-based position).
+The above query will display the item with ASIN B00728DYLA on page 2 as a JSON object. The `-s` flag accepts both ASIN and numeric index (0-based position).
 
 #### Product Lookup by ASIN
 
-You can also fetch detailed product information directly by ASIN using the `-P/--product` flag:
+You can also fetch detailed product information directly by ASIN using the `-a/--asin` flag:
 
 ```
-$ amzsear -P B00006IFHD
+$ amzsear -a B00006IFHD
 ```
 
 ```
@@ -99,7 +99,7 @@ This fetches the product page and extracts detailed information including brand,
 Use `-b/--browser` to open the product page in your default browser:
 
 ```
-$ amzsear -P B00006IFHD -b
+$ amzsear -a B00006IFHD -b
 ```
 
 For more examples and for extended usage information see the [CLI Readme](docs/cli/README.md).

--- a/amzsear.egg-info/PKG-INFO
+++ b/amzsear.egg-info/PKG-INFO
@@ -1,4 +1,4 @@
-Metadata-Version: 1.0
+Metadata-Version: 2.4
 Name: amzsear
 Version: 2.0.1
 Summary: The unofficial Amazon search CLI & Python API
@@ -6,7 +6,17 @@ Home-page: https://github.com/asherAgs/amzSear
 Author: Asher Silvers
 Author-email: ashersilvers@gmail.com
 License: MIT
-Description-Content-Type: UNKNOWN
-Description: UNKNOWN
 Keywords: amazon search product products python
-Platform: UNKNOWN
+License-File: LICENSE.txt
+Requires-Dist: lxml>=4.9.1
+Requires-Dist: cssselect>=1.1.0
+Requires-Dist: lxml_html_clean>=0.1.0
+Requires-Dist: requests>=2.20.0
+Dynamic: author
+Dynamic: author-email
+Dynamic: home-page
+Dynamic: keywords
+Dynamic: license
+Dynamic: license-file
+Dynamic: requires-dist
+Dynamic: summary

--- a/amzsear.egg-info/SOURCES.txt
+++ b/amzsear.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+LICENSE.txt
 MANIFEST.in
 README.md
 requirements.txt
@@ -8,6 +9,7 @@ amzsear.egg-info/PKG-INFO
 amzsear.egg-info/SOURCES.txt
 amzsear.egg-info/dependency_links.txt
 amzsear.egg-info/entry_points.txt
+amzsear.egg-info/requires.txt
 amzsear.egg-info/top_level.txt
 amzsear/cli/__init__.py
 amzsear/cli/cli.py

--- a/amzsear.egg-info/entry_points.txt
+++ b/amzsear.egg-info/entry_points.txt
@@ -1,3 +1,2 @@
 [console_scripts]
 amzsear = amzsear.cli.cli:run
-

--- a/amzsear.egg-info/requires.txt
+++ b/amzsear.egg-info/requires.txt
@@ -1,0 +1,4 @@
+lxml>=4.9.1
+cssselect>=1.1.0
+lxml_html_clean>=0.1.0
+requests>=2.20.0

--- a/amzsear/__init__.py
+++ b/amzsear/__init__.py
@@ -1,4 +1,21 @@
 try:
     from amzsear.core.AmzSear import AmzSear
+    from amzsear.core.AmzProduct import AmzProduct
+    from amzsear.core.AmzProductDetails import AmzProductDetails
+    from amzsear.core.AmzReviews import AmzReviews, AmzReview
+    from amzsear.core.selectors import DetailLevel
 except ImportError:
-    from .amzsear.core.AmzSear import AmzSear
+    from .core.AmzSear import AmzSear
+    from .core.AmzProduct import AmzProduct
+    from .core.AmzProductDetails import AmzProductDetails
+    from .core.AmzReviews import AmzReviews, AmzReview
+    from .core.selectors import DetailLevel
+
+__all__ = [
+    'AmzSear',
+    'AmzProduct',
+    'AmzProductDetails',
+    'AmzReviews',
+    'AmzReview',
+    'DetailLevel',
+]

--- a/amzsear/__init__.py
+++ b/amzsear/__init__.py
@@ -1,3 +1,7 @@
+"""amzSear - The unofficial Amazon search CLI & Python API."""
+
+__version__ = '2.0.2'
+
 try:
     from amzsear.core.AmzSear import AmzSear
     from amzsear.core.AmzProduct import AmzProduct
@@ -12,6 +16,7 @@ except ImportError:
     from .core.selectors import DetailLevel
 
 __all__ = [
+    '__version__',
     'AmzSear',
     'AmzProduct',
     'AmzProductDetails',

--- a/amzsear/__init__.py
+++ b/amzsear/__init__.py
@@ -1,6 +1,6 @@
 """amzSear - The unofficial Amazon search CLI & Python API."""
 
-__version__ = '2.0.2'
+__version__ = '3.0.0'
 
 try:
     from amzsear.core.AmzSear import AmzSear

--- a/amzsear/__init__.py
+++ b/amzsear/__init__.py
@@ -1,6 +1,6 @@
 """amzSear - The unofficial Amazon search CLI & Python API."""
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 try:
     from amzsear.core.AmzSear import AmzSear

--- a/amzsear/cli/cli.py
+++ b/amzsear/cli/cli.py
@@ -191,7 +191,9 @@ def print_product_json(product, verbose=False):
     """Output product details as JSON."""
     data = {'asin': product.get_asin(), 'product_url': product.product_url}
 
-    if product.details:
+    if product._fetch_error:
+        data['error'] = product._fetch_error
+    elif product.details:
         if verbose:
             data['details'] = product.details.to_dict()
         else:
@@ -211,7 +213,9 @@ def print_product_verbose(product):
     print(f"URL: {product.product_url}")
     print()
 
-    if product.details:
+    if product._fetch_error:
+        print(f"Error: {product._fetch_error}")
+    elif product.details:
         details = product.details
         for key, value in details.items():
             if isinstance(value, dict):
@@ -234,6 +238,10 @@ def print_product_short(product):
     details = product.details
 
     print(f"ASIN:   {asin}")
+
+    if product._fetch_error:
+        print(f"Error: {product._fetch_error}")
+        return
 
     if details:
         title = details.full_title or 'N/A'

--- a/amzsear/cli/cli.py
+++ b/amzsear/cli/cli.py
@@ -1,9 +1,11 @@
 try:
-    from amzsear import AmzSear
-    from amzsear.core.consts import DEFAULT_REGION, REGION_CODES
+    from amzsear import AmzSear, AmzProduct, DetailLevel
+    from amzsear.core.consts import DEFAULT_REGION, REGION_CODES, PRODUCT_URL
+    from amzsear.core import build_base_url
 except ImportError:
-    from .amzsear import AmzSear
-    from .amzsear.core.consts import DEFAULT_REGION, REGION_CODES
+    from .amzsear import AmzSear, AmzProduct, DetailLevel
+    from .amzsear.core.consts import DEFAULT_REGION, REGION_CODES, PRODUCT_URL
+    from .amzsear.core import build_base_url
 
 import argparse
 import webbrowser
@@ -18,14 +20,24 @@ def run(*passed_args):
     args = parser.parse_args(*passed_args) # the parser defaults to sys args if nothing passed
     args = vars(args)
 
-    amz_args = {x:y for x,y in args.items() if x not in ['item','output','dont_open']}
+    # Handle product lookup mode
+    if args.get('product'):
+        run_product(args)
+        return
+
+    # Validate: query is required for search mode
+    if not args.get('query'):
+        parser.error('query is required (or use --product ASIN)')
+
+    # Handle search mode
+    amz_args = {x:y for x,y in args.items() if x not in ['item','output','dont_open','product']}
     out = AmzSear(**amz_args)
 
     if args['item'] != None:
         # single item selection
         prod = out[args['item']]
         out = AmzSear(products=[prod]) # error raised if not found
-        out._urls = [prod.product_url] 
+        out._urls = [prod.product_url]
 
 
     # handle output types
@@ -45,11 +57,44 @@ def run(*passed_args):
             webbrowser.open(url)
 
 
+def run_product(args):
+    """Handle product lookup by ASIN."""
+    asin = args['product']
+    region = args.get('region', DEFAULT_REGION)
+
+    # Create a minimal AmzProduct with just the product_url set
+    product = AmzProduct()
+    base_url = build_base_url(region)
+    product.product_url = PRODUCT_URL % (base_url, asin)
+    product._region = region
+    product._is_valid = True
+
+    # Fetch BASIC level details
+    product.fetch_details(level=DetailLevel.BASIC, region=region)
+
+    # Handle output types
+    if args['output'] == 'short':
+        print_product_short(product)
+    elif args['output'] == 'verbose':
+        print_product_verbose(product)
+    elif args['output'] == 'csv':
+        print_product_csv(product)
+    elif args['output'] == 'json':
+        print_product_json(product)
+    # elif args['output'] == 'quiet' --> no output
+
+    if args['dont_open'] != True:
+        webbrowser.open(product.product_url)
+
+
 
 def get_parser():
     parser = argparse.ArgumentParser(description='The unofficial Amazon search CLI')
 
-    parser.add_argument('query', type=str, help='The query string to be searched')
+    parser.add_argument('query', type=str, nargs='?', default=None,
+        help='The query string to be searched')
+    parser.add_argument('-P','--product', type=str, default=None,
+        help='Fetch product details by ASIN instead of searching')
     parser.add_argument('-p','--page', type=int,
         help='The page number to be searched (defaults to 1)', default=1)
     parser.add_argument('-i','--item', type=str,
@@ -117,6 +162,86 @@ def print_short(cls):
 
     for row in rows:
         print(format_str.format(*[row.get(x,'') for x in fields])) # print in order
+
+
+# Product output formatters
+def print_product_json(product):
+    """Output product details as JSON."""
+    data = {'asin': product.get_asin()}
+    data['product_url'] = product.product_url
+
+    if product.details:
+        data['details'] = product.details.to_dict()
+
+    print(json.dumps(data, indent=2))
+
+
+def print_product_csv(product):
+    """Output product details as CSV."""
+    data = {'asin': product.get_asin(), 'product_url': product.product_url}
+
+    if product.details:
+        details_dict = product.details.to_dict(flatten=True)
+        # Flatten lists to strings for CSV
+        for k, v in details_dict.items():
+            if isinstance(v, list):
+                details_dict[k] = '; '.join(str(x) for x in v)
+            elif isinstance(v, dict):
+                details_dict[k] = json.dumps(v)
+        data.update(details_dict)
+
+    writer = csv.DictWriter(sys.stdout, data.keys(), quoting=csv.QUOTE_ALL)
+    writer.writeheader()
+    writer.writerows([data])
+
+
+def print_product_verbose(product):
+    """Output full product details."""
+    print(f"ASIN: {product.get_asin()}")
+    print(f"URL:  {product.product_url}")
+    print()
+
+    if product.details:
+        print(product.details)
+    else:
+        print("No details available")
+
+
+def print_product_short(product):
+    """Output product summary."""
+    asin = product.get_asin() or 'N/A'
+    details = product.details
+
+    print(f"ASIN:   {asin}")
+
+    if details:
+        title = details.full_title or 'N/A'
+        if len(title) > 70:
+            title = title[:67] + '...'
+        print(f"Title:  {title}")
+
+        brand = details.brand or 'N/A'
+        print(f"Brand:  {brand}")
+
+        if details.average_rating:
+            rating_str = f"{details.average_rating:.1f}/5"
+            if details.review_count:
+                rating_str += f" ({details.review_count:,} reviews)"
+            print(f"Rating: {rating_str}")
+
+        if details.about_items:
+            print(f"\nAbout this item ({len(details.about_items)} points):")
+            for i, item in enumerate(details.about_items[:3], 1):
+                text = item[:80] + '...' if len(item) > 80 else item
+                print(f"  {i}. {text}")
+            if len(details.about_items) > 3:
+                print(f"  ... and {len(details.about_items) - 3} more")
+
+        if details.technical_details:
+            print(f"\nTechnical details ({len(details.technical_details)} fields)")
+    else:
+        print("No details available (fetch may have failed)")
+
 
 if __name__ == '__main__':
     run()

--- a/amzsear/cli/cli.py
+++ b/amzsear/cli/cli.py
@@ -128,13 +128,13 @@ def print_verbose(cls):
 
 
 def print_short(cls):
-    fields = ['','Title','Prices','Rating']
+    fields = ['ASIN','Title','Prices','Rating']
 
     rows = [{f:f for f in fields}]
     for index, product in cls.items():
         temp_dict = {}
 
-        temp_dict[''] = index
+        temp_dict['ASIN'] = product.get_asin() or index[:10]
 
         # get price in format '$nn.nn-$mm.mm'
         price_tup = {product.prices[k]:product.get_prices(k) for k in product.prices}

--- a/amzsear/cli/cli.py
+++ b/amzsear/cli/cli.py
@@ -21,21 +21,21 @@ def run(*passed_args):
     args = vars(args)
 
     # Handle product lookup mode
-    if args.get('product'):
+    if args.get('asin'):
         run_product(args)
         return
 
     # Validate: query is required for search mode
     if not args.get('query'):
-        parser.error('query is required (or use --product ASIN)')
+        parser.error('query is required (or use --asin ASIN)')
 
     # Handle search mode
-    amz_args = {x:y for x,y in args.items() if x not in ['item','output','browser','product']}
+    amz_args = {x:y for x,y in args.items() if x not in ['select','output','browser','asin']}
     out = AmzSear(**amz_args)
 
-    if args['item'] != None:
+    if args['select'] != None:
         # single item selection - accept ASIN or numeric index
-        item_key = args['item']
+        item_key = args['select']
         if item_key.isdigit():
             # Numeric index - get by position
             prod = out.rget(int(item_key), raise_error=True)
@@ -63,7 +63,7 @@ def run(*passed_args):
 
 def run_product(args):
     """Handle product lookup by ASIN."""
-    asin = args['product']
+    asin = args['asin']
     region = args.get('region', DEFAULT_REGION)
 
     # Create a minimal AmzProduct with just the product_url set
@@ -97,12 +97,12 @@ def get_parser():
 
     parser.add_argument('query', type=str, nargs='?', default=None,
         help='The query string to be searched')
-    parser.add_argument('-P','--product', type=str, default=None,
+    parser.add_argument('-a','--asin', type=str, default=None,
         help='Fetch product details by ASIN instead of searching')
     parser.add_argument('-p','--page', type=int,
         help='The page number to be searched (defaults to 1)', default=1)
-    parser.add_argument('-i','--item', type=str,
-        help='Select item by ASIN or numeric index (0-based position)', default=None)
+    parser.add_argument('-s','--select', type=str,
+        help='Select result by ASIN or numeric index (0-based position)', default=None)
     parser.add_argument('-r','--region', type=str, choices=REGION_CODES,
         default=DEFAULT_REGION, help='The amazon country/region to be searched')
 

--- a/amzsear/core/AmzProduct.py
+++ b/amzsear/core/AmzProduct.py
@@ -1,23 +1,21 @@
 import re
-from urllib import request
-from lxml import html as html_module
 
 try:
     from amzsear.core.AmzBase import AmzBase
-    from amzsear.core import requires_valid_data, capture_exception, build_url, build_base_url
+    from amzsear.core import requires_valid_data, capture_exception, build_url, build_base_url, fetch_html
     from amzsear.core.AmzRating import AmzRating
     from amzsear.core.AmzProductDetails import AmzProductDetails
     from amzsear.core.AmzReviews import AmzReviews
     from amzsear.core.selectors import DetailLevel
-    from amzsear.core.consts import PRODUCT_URL, REVIEWS_URL, QA_URL, DETAIL_HEADERS, DEFAULT_REGION
+    from amzsear.core.consts import PRODUCT_URL, REVIEWS_URL, QA_URL, DEFAULT_REGION
 except ImportError:
     from .AmzBase import AmzBase
-    from . import requires_valid_data, capture_exception, build_url, build_base_url
+    from . import requires_valid_data, capture_exception, build_url, build_base_url, fetch_html
     from .AmzRating import AmzRating
     from .AmzProductDetails import AmzProductDetails
     from .AmzReviews import AmzReviews
     from .selectors import DetailLevel
-    from .consts import PRODUCT_URL, REVIEWS_URL, QA_URL, DETAIL_HEADERS, DEFAULT_REGION
+    from .consts import PRODUCT_URL, REVIEWS_URL, QA_URL, DEFAULT_REGION
 """
     The AmzProduct class extends the AmzBase class and, as such the following
     attributes are available to be called as an index call or as an attribute:
@@ -145,24 +143,6 @@ class AmzProduct(AmzBase):
             result = result.group(1)
         return result
 
-    def _fetch_html(self, url):
-        """
-        Fetch HTML content from a URL.
-
-        Args:
-            url: The URL to fetch
-
-        Returns:
-            lxml HTML element or None on failure
-        """
-        try:
-            req = request.Request(url, headers=DETAIL_HEADERS)
-            response = request.urlopen(req)
-            html_content = response.read()
-            return html_module.fromstring(html_content)
-        except Exception:
-            return None
-
     def fetch_details(self, level=None, region=None):
         """
         Fetch detailed product information from Amazon.
@@ -201,14 +181,14 @@ class AmzProduct(AmzBase):
         # Level 1: Fetch product page details
         if level.value >= DetailLevel.BASIC.value:
             product_url = PRODUCT_URL % (base_url, asin)
-            html_elem = self._fetch_html(product_url)
+            html_elem = fetch_html(product_url)
             if html_elem is not None:
                 self.details = AmzProductDetails(html_elem)
 
         # Level 2: Fetch reviews page
         if level.value >= DetailLevel.REVIEWS.value:
             reviews_url = REVIEWS_URL % (base_url, asin)
-            html_elem = self._fetch_html(reviews_url)
+            html_elem = fetch_html(reviews_url)
             if html_elem is not None:
                 self.reviews = AmzReviews(html_elem)
 

--- a/amzsear/core/AmzProduct.py
+++ b/amzsear/core/AmzProduct.py
@@ -61,6 +61,8 @@ class AmzProduct(AmzBase):
                 setattr(self, k, v)
             if len(html_dict) > 0:
                 self._is_valid = True
+                # Set _index to ASIN for use as key in AmzSear collection
+                self._index = self.get_asin()
 
     """
         Private method - used in to initialise fields from HTML
@@ -101,8 +103,8 @@ class AmzProduct(AmzBase):
         extras = [re.sub('\s+',' ', x.text_content().strip()) for x in extras]
         d['extra_attributes'] = dict(list(zip(extras,extras[1:]))[::2])
 
-        # _index is not used explicitly in _all_attrs but can be referenced elsewhere
-        d['_index'] = root.get('id','').split('_')[-1]
+        # _index is the ASIN, used as key in AmzSear collection
+        d['_index'] = None  # Will be set from product_url after extraction
 
         # clean up before returning
         return dict(map(lambda k: (k, d[k].strip() if isinstance(d[k],str) else d[k]), d)) 

--- a/amzsear/core/AmzProduct.py
+++ b/amzsear/core/AmzProduct.py
@@ -49,12 +49,12 @@ class AmzProduct(AmzBase):
     subtext = None
     details = None  # AmzProductDetails object (populated by fetch_details)
     reviews = None  # AmzReviews object (populated by fetch_details)
-    _region = DEFAULT_REGION  # Region for URL building
 
     _all_attrs = ['title','product_url','image_url','rating','prices',
         'extra_attributes', 'subtext', 'details', 'reviews']
 
-    def __init__(self, html_element=None):
+    def __init__(self, html_element=None, region=DEFAULT_REGION):
+        self._region = region
         if html_element != None:
             html_dict = self._get_from_html(html_element)
             for k,v in html_dict.items():
@@ -76,7 +76,7 @@ class AmzProduct(AmzBase):
 
         title_root = [x for x in root.cssselect('a') if len(x.cssselect('h2')) > 0][0]
         d['title'] = ''.join([x.text_content() for x in title_root.cssselect('h2')])
-        d['product_url'] = build_url(title_root.get('href'))
+        d['product_url'] = build_url(title_root.get('href'), region=self._region)
         for elem in title_root.getparent().getparent().cssselect('div[class="a-row a-spacing-none"]'):
             temp_subtext = ''.join([x.text_content() for x in elem.cssselect('span[class*="a-size-small"]')])
             if len(temp_subtext) > 0:

--- a/amzsear/core/AmzProductDetails.py
+++ b/amzsear/core/AmzProductDetails.py
@@ -1,0 +1,199 @@
+"""
+AmzProductDetails class for storing detailed product information
+fetched from Amazon product pages.
+"""
+
+try:
+    from amzsear.core.AmzBase import AmzBase
+except ImportError:
+    from .AmzBase import AmzBase
+
+
+class AmzProductDetails(AmzBase):
+    """
+    Contains detailed product information fetched from an Amazon product page.
+
+    All fields return None if not available (graceful defaults).
+
+    Attributes:
+        full_title (str): Complete product title
+        brand (str): Brand/manufacturer name
+        brand_url (str): URL to brand's Amazon store
+        about_items (list): "About this item" bullet points
+        technical_details (dict): Technical specifications table
+        product_description (str): Product description text
+        image_urls (list): URLs to all product images
+        reviews_summary (str): AI-generated reviews summary (if available)
+        star_distribution (dict): Rating distribution {5: percentage, 4: percentage, ...}
+        review_count (int): Total number of reviews
+        average_rating (float): Average star rating
+    """
+
+    full_title = None
+    brand = None
+    brand_url = None
+    about_items = None
+    technical_details = None
+    product_description = None
+    image_urls = None
+    reviews_summary = None
+    star_distribution = None
+    review_count = None
+    average_rating = None
+
+    _all_attrs = [
+        'full_title', 'brand', 'brand_url', 'about_items',
+        'technical_details', 'product_description', 'image_urls',
+        'reviews_summary', 'star_distribution', 'review_count', 'average_rating'
+    ]
+
+    def __init__(self, html_element=None):
+        """
+        Initialize AmzProductDetails.
+
+        Args:
+            html_element: lxml HTML element from product page (optional)
+        """
+        if html_element is not None:
+            self._parse_from_html(html_element)
+
+    def _parse_from_html(self, root):
+        """
+        Parse product details from HTML element.
+
+        Args:
+            root: lxml HTML root element
+        """
+        import re
+
+        try:
+            from amzsear.core.selectors import (
+                PRODUCT_TITLE, BRAND_LINK, FEATURE_BULLETS,
+                PRODUCT_DESCRIPTION, PRODUCT_DESCRIPTION_ALT,
+                TECH_DETAILS_TABLE, TECH_DETAILS_ROWS,
+                PRODUCT_DETAILS_TABLE, PRODUCT_DETAILS_TABLE_ALT,
+                IMAGE_GALLERY, MAIN_IMAGE, IMAGE_THUMB_LIST,
+                REVIEW_COUNT, RATING_STARS, STAR_HISTOGRAM,
+                CUSTOMER_REVIEWS_SUMMARY
+            )
+        except ImportError:
+            from .selectors import (
+                PRODUCT_TITLE, BRAND_LINK, FEATURE_BULLETS,
+                PRODUCT_DESCRIPTION, PRODUCT_DESCRIPTION_ALT,
+                TECH_DETAILS_TABLE, TECH_DETAILS_ROWS,
+                PRODUCT_DETAILS_TABLE, PRODUCT_DETAILS_TABLE_ALT,
+                IMAGE_GALLERY, MAIN_IMAGE, IMAGE_THUMB_LIST,
+                REVIEW_COUNT, RATING_STARS, STAR_HISTOGRAM,
+                CUSTOMER_REVIEWS_SUMMARY
+            )
+
+        # Full title
+        title_elem = root.cssselect(PRODUCT_TITLE)
+        if title_elem:
+            self.full_title = title_elem[0].text_content().strip()
+
+        # Brand
+        brand_elem = root.cssselect(BRAND_LINK)
+        if brand_elem:
+            self.brand = brand_elem[0].text_content().strip()
+            # Remove "Visit the X Store" prefix if present
+            if self.brand.startswith('Visit the '):
+                self.brand = self.brand.replace('Visit the ', '').replace(' Store', '')
+            elif self.brand.startswith('Brand: '):
+                self.brand = self.brand.replace('Brand: ', '')
+            href = brand_elem[0].get('href')
+            if href:
+                self.brand_url = href
+
+        # About this item bullet points
+        bullet_elems = root.cssselect(FEATURE_BULLETS)
+        if bullet_elems:
+            self.about_items = []
+            for elem in bullet_elems:
+                text = elem.text_content().strip()
+                if text and text not in ['About this item']:
+                    self.about_items.append(text)
+
+        # Technical details
+        self.technical_details = {}
+
+        # Try multiple selectors for tech details
+        for selector in [TECH_DETAILS_ROWS, PRODUCT_DETAILS_TABLE, PRODUCT_DETAILS_TABLE_ALT]:
+            rows = root.cssselect(selector)
+            if rows:
+                for row in rows:
+                    cells = row.cssselect('th, td')
+                    if len(cells) >= 2:
+                        key = cells[0].text_content().strip()
+                        value = cells[1].text_content().strip()
+                        # Clean up common artifacts
+                        key = re.sub(r'[\u200e\u200f]', '', key).strip()
+                        value = re.sub(r'[\u200e\u200f]', '', value).strip()
+                        if key and value:
+                            self.technical_details[key] = value
+
+        if not self.technical_details:
+            self.technical_details = None
+
+        # Product description
+        desc_elem = root.cssselect(PRODUCT_DESCRIPTION)
+        if not desc_elem:
+            desc_elem = root.cssselect(PRODUCT_DESCRIPTION_ALT)
+        if desc_elem:
+            self.product_description = desc_elem[0].text_content().strip()
+
+        # Image URLs
+        self.image_urls = []
+        for selector in [IMAGE_GALLERY, IMAGE_THUMB_LIST, MAIN_IMAGE]:
+            img_elems = root.cssselect(selector)
+            for img in img_elems:
+                src = img.get('src') or img.get('data-old-hires') or img.get('data-a-dynamic-image')
+                if src and src not in self.image_urls:
+                    # Skip tiny placeholder images
+                    if 'sprite' not in src.lower() and 'transparent' not in src.lower():
+                        self.image_urls.append(src)
+
+        if not self.image_urls:
+            self.image_urls = None
+
+        # Reviews summary (AI-generated)
+        summary_elem = root.cssselect(CUSTOMER_REVIEWS_SUMMARY)
+        if summary_elem:
+            self.reviews_summary = summary_elem[0].text_content().strip()
+
+        # Review count
+        count_elem = root.cssselect(REVIEW_COUNT)
+        if count_elem:
+            count_text = count_elem[0].text_content().strip()
+            # Extract number from text like "1,234 ratings" or "1,234 global ratings"
+            match = re.search(r'[\d,]+', count_text)
+            if match:
+                self.review_count = int(match.group().replace(',', ''))
+
+        # Average rating
+        rating_elem = root.cssselect(RATING_STARS)
+        if rating_elem:
+            rating_text = rating_elem[0].get('title', '') or rating_elem[0].text_content()
+            match = re.search(r'(\d+\.?\d*)\s*out\s*of\s*5', rating_text)
+            if match:
+                self.average_rating = float(match.group(1))
+
+        # Star distribution
+        histogram = root.cssselect(STAR_HISTOGRAM)
+        if histogram:
+            self.star_distribution = {}
+            for row in histogram:
+                text = row.text_content()
+                # Match patterns like "5 star 85%"
+                match = re.search(r'(\d)\s*star\s*(\d+)%', text)
+                if match:
+                    stars = int(match.group(1))
+                    percentage = int(match.group(2))
+                    self.star_distribution[stars] = percentage
+
+        if not self.star_distribution:
+            self.star_distribution = None
+
+        # Mark as valid if we got at least a title
+        if self.full_title:
+            self._is_valid = True

--- a/amzsear/core/AmzProductDetails.py
+++ b/amzsear/core/AmzProductDetails.py
@@ -54,6 +54,7 @@ class AmzProductDetails(AmzBase):
         Args:
             html_element: lxml HTML element from product page (optional)
         """
+        super().__init__()
         if html_element is not None:
             self._parse_from_html(html_element)
 

--- a/amzsear/core/AmzReviews.py
+++ b/amzsear/core/AmzReviews.py
@@ -1,0 +1,229 @@
+"""
+AmzReview and AmzReviews classes for storing customer review data
+fetched from Amazon product review pages.
+"""
+import re
+
+try:
+    from amzsear.core.AmzBase import AmzBase
+except ImportError:
+    from .AmzBase import AmzBase
+
+
+class AmzReview(AmzBase):
+    """
+    Represents a single customer review.
+
+    Attributes:
+        reviewer (str): Reviewer's display name
+        rating (float): Star rating (1-5)
+        title (str): Review title
+        date (str): Review date
+        text (str): Full review text
+        verified (bool): Whether this is a verified purchase
+        helpful_count (int): Number of people who found this helpful
+        images (list): URLs to images attached to review
+    """
+
+    reviewer = None
+    rating = None
+    title = None
+    date = None
+    text = None
+    verified = None
+    helpful_count = None
+    images = None
+
+    _all_attrs = [
+        'reviewer', 'rating', 'title', 'date',
+        'text', 'verified', 'helpful_count', 'images'
+    ]
+
+    def __init__(self, html_element=None):
+        """
+        Initialize AmzReview.
+
+        Args:
+            html_element: lxml HTML element for a single review (optional)
+        """
+        if html_element is not None:
+            self._parse_from_html(html_element)
+
+    def _parse_from_html(self, elem):
+        """
+        Parse review data from HTML element.
+
+        Args:
+            elem: lxml HTML element for a single review
+        """
+        try:
+            from amzsear.core.selectors import (
+                REVIEW_TITLE, REVIEW_RATING, REVIEW_DATE,
+                REVIEW_BODY, REVIEW_AUTHOR, REVIEW_VERIFIED,
+                REVIEW_HELPFUL, REVIEW_IMAGES
+            )
+        except ImportError:
+            from .selectors import (
+                REVIEW_TITLE, REVIEW_RATING, REVIEW_DATE,
+                REVIEW_BODY, REVIEW_AUTHOR, REVIEW_VERIFIED,
+                REVIEW_HELPFUL, REVIEW_IMAGES
+            )
+
+        # Reviewer name
+        author_elem = elem.cssselect(REVIEW_AUTHOR)
+        if author_elem:
+            self.reviewer = author_elem[0].text_content().strip()
+
+        # Rating
+        rating_elem = elem.cssselect(REVIEW_RATING)
+        if rating_elem:
+            rating_text = rating_elem[0].text_content()
+            match = re.search(r'(\d+\.?\d*)\s*out\s*of\s*5', rating_text)
+            if match:
+                self.rating = float(match.group(1))
+
+        # Title
+        title_elem = elem.cssselect(REVIEW_TITLE)
+        if title_elem:
+            # Title often includes rating text, extract just the title
+            title_text = title_elem[0].text_content().strip()
+            # Remove rating prefix like "5.0 out of 5 stars"
+            title_text = re.sub(r'^\d+\.?\d*\s*out\s*of\s*5\s*stars?\s*', '', title_text)
+            self.title = title_text.strip()
+
+        # Date
+        date_elem = elem.cssselect(REVIEW_DATE)
+        if date_elem:
+            date_text = date_elem[0].text_content().strip()
+            # Extract date from text like "Reviewed in the United States on December 3, 2024"
+            match = re.search(r'on\s+(.+)$', date_text)
+            if match:
+                self.date = match.group(1).strip()
+            else:
+                self.date = date_text
+
+        # Review text
+        body_elem = elem.cssselect(REVIEW_BODY)
+        if body_elem:
+            self.text = body_elem[0].text_content().strip()
+
+        # Verified purchase
+        verified_elem = elem.cssselect(REVIEW_VERIFIED)
+        self.verified = len(verified_elem) > 0
+
+        # Helpful count
+        helpful_elem = elem.cssselect(REVIEW_HELPFUL)
+        if helpful_elem:
+            helpful_text = helpful_elem[0].text_content()
+            match = re.search(r'([\d,]+)\s*people?\s*found', helpful_text)
+            if match:
+                self.helpful_count = int(match.group(1).replace(',', ''))
+            elif 'One person' in helpful_text:
+                self.helpful_count = 1
+            else:
+                self.helpful_count = 0
+        else:
+            self.helpful_count = 0
+
+        # Review images
+        img_elems = elem.cssselect(REVIEW_IMAGES)
+        if img_elems:
+            self.images = []
+            for img in img_elems:
+                src = img.get('src')
+                if src:
+                    self.images.append(src)
+            if not self.images:
+                self.images = None
+
+        # Mark as valid if we have at least text or title
+        if self.text or self.title:
+            self._is_valid = True
+
+
+class AmzReviews(AmzBase):
+    """
+    Collection of customer reviews for a product.
+
+    Attributes:
+        reviews (list): List of AmzReview objects
+        total_count (int): Total number of reviews
+        feature_ratings (dict): Feature-specific ratings (e.g., {"Sound quality": 4.5})
+    """
+
+    reviews = None
+    total_count = None
+    feature_ratings = None
+
+    _all_attrs = ['reviews', 'total_count', 'feature_ratings']
+
+    def __init__(self, html_element=None):
+        """
+        Initialize AmzReviews.
+
+        Args:
+            html_element: lxml HTML element from reviews page (optional)
+        """
+        if html_element is not None:
+            self._parse_from_html(html_element)
+
+    def _parse_from_html(self, root):
+        """
+        Parse reviews from HTML element.
+
+        Args:
+            root: lxml HTML root element from reviews page
+        """
+        try:
+            from amzsear.core.selectors import REVIEW_ITEM, REVIEW_COUNT
+        except ImportError:
+            from .selectors import REVIEW_ITEM, REVIEW_COUNT
+
+        # Parse individual reviews
+        review_elems = root.cssselect(REVIEW_ITEM)
+        if review_elems:
+            self.reviews = []
+            for elem in review_elems:
+                review = AmzReview(elem)
+                if review.is_valid():
+                    self.reviews.append(review)
+
+        if not self.reviews:
+            self.reviews = []
+
+        # Total count
+        count_elem = root.cssselect(REVIEW_COUNT)
+        if count_elem:
+            count_text = count_elem[0].text_content()
+            match = re.search(r'[\d,]+', count_text)
+            if match:
+                self.total_count = int(match.group().replace(',', ''))
+
+        # Feature ratings (these are often in a separate widget)
+        # Look for feature rating buttons
+        feature_buttons = root.cssselect('[data-hook="cr-insights-widget-aspects"] button')
+        if feature_buttons:
+            self.feature_ratings = {}
+            for btn in feature_buttons:
+                text = btn.text_content()
+                # Extract feature and count, e.g., "Sound quality (2K)"
+                match = re.match(r'([^(]+)\s*\(([^)]+)\)', text)
+                if match:
+                    feature = match.group(1).strip()
+                    count = match.group(2).strip()
+                    self.feature_ratings[feature] = count
+
+        if not self.feature_ratings:
+            self.feature_ratings = None
+
+        # Mark as valid if we have reviews
+        if self.reviews:
+            self._is_valid = True
+
+    def __len__(self):
+        """Return number of reviews."""
+        return len(self.reviews) if self.reviews else 0
+
+    def __iter__(self):
+        """Iterate over reviews."""
+        return iter(self.reviews) if self.reviews else iter([])

--- a/amzsear/core/AmzReviews.py
+++ b/amzsear/core/AmzReviews.py
@@ -46,6 +46,7 @@ class AmzReview(AmzBase):
         Args:
             html_element: lxml HTML element for a single review (optional)
         """
+        super().__init__()
         if html_element is not None:
             self._parse_from_html(html_element)
 
@@ -164,6 +165,7 @@ class AmzReviews(AmzBase):
         Args:
             html_element: lxml HTML element from reviews page (optional)
         """
+        super().__init__()
         if html_element is not None:
             self._parse_from_html(html_element)
 

--- a/amzsear/core/AmzSear.py
+++ b/amzsear/core/AmzSear.py
@@ -89,13 +89,16 @@ class AmzSear(object):
                 products = [AmzProduct(elem) for elem in products]
         if products != None:
             products = get_iter(products)
-            products = [prod for prod in products if prod.is_valid()]
-            self._products += products
-            self._indexes += [prod._index for prod in products]
+            products = [prod for prod in products if prod.is_valid() and prod._index]
+            # Deduplicate by ASIN - keep first occurrence only
+            for prod in products:
+                if prod._index not in self._indexes:
+                    self._products.append(prod)
+                    self._indexes.append(prod._index)
 
     def __repr__(self):
         out = []
-        max_index_len = 10
+        max_index_len = 12  # ASIN is 10 chars + padding
         for index, product in self.items():
             temp_repr = repr(index) + ':' + max_index_len*' '
             temp_repr = temp_repr[:max_index_len] + repr(product)

--- a/amzsear/core/AmzSear.py
+++ b/amzsear/core/AmzSear.py
@@ -86,7 +86,7 @@ class AmzSear(object):
             for html_el in html_element:
                 products = html_el.cssselect('div[data-asin][data-component-type="s-search-result"]')
                 products = [x for x in products if x.cssselect('h2')]
-                products = [AmzProduct(elem) for elem in products]
+                products = [AmzProduct(elem, region=region) for elem in products]
         if products != None:
             products = get_iter(products)
             products = [prod for prod in products if prod.is_valid() and prod._index]

--- a/amzsear/core/AmzSear.py
+++ b/amzsear/core/AmzSear.py
@@ -1,14 +1,13 @@
 from lxml import html as html_module
 from lxml.html import clean
-from urllib import request
 
 try:
-    from amzsear.core import build_url
-    from amzsear.core.consts import URL_ADDONS, SEARCH_URL, DEFAULT_REGION
+    from amzsear.core import build_url, fetch_html
+    from amzsear.core.consts import DEFAULT_REGION
     from amzsear.core.AmzProduct import AmzProduct
 except ImportError:
-    from . import build_url
-    from .consts import URL_ADDONS, SEARCH_URL, DEFAULT_REGION
+    from . import build_url, fetch_html
+    from .consts import DEFAULT_REGION
     from .AmzProduct import AmzProduct
 
 """
@@ -74,17 +73,11 @@ class AmzSear(object):
         if url != None:
             url = get_iter(url)
             self._urls = url
-            html = []
+            html_element = []
             for u in url:
-                req = request.Request(
-                    build_url(u),
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
-                        "Accept-Language": "en-US,en;q=0.9",
-                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                    }
-                )
-                html.append(request.urlopen(req).read())
+                elem = fetch_html(build_url(u))
+                if elem is not None:
+                    html_element.append(elem)
         if html != None:
             html = get_iter(html)
             html_element = [html_module.fromstring(h) for h in html]

--- a/amzsear/core/AmzSear.py
+++ b/amzsear/core/AmzSear.py
@@ -68,10 +68,12 @@ class AmzSear(object):
             html_element = [html_module.fromstring(h) for h in html]
         if html_element is not None:
             html_element = get_iter(html_element)
+            products = []
             for html_el in html_element:
-                products = html_el.cssselect('div[data-asin][data-component-type="s-search-result"]')
-                products = [x for x in products if x.cssselect('h2')]
-                products = [AmzProduct(elem, region=region) for elem in products]
+                page_products = html_el.cssselect('div[data-asin][data-component-type="s-search-result"]')
+                page_products = [x for x in page_products if x.cssselect('h2')]
+                page_products = [AmzProduct(elem, region=region) for elem in page_products]
+                products.extend(page_products)
         if products is not None:
             products = get_iter(products)
             products = [prod for prod in products if prod.is_valid() and prod._index]

--- a/amzsear/core/AmzSear.py
+++ b/amzsear/core/AmzSear.py
@@ -7,9 +7,9 @@ try:
     from amzsear.core.consts import URL_ADDONS, SEARCH_URL, DEFAULT_REGION
     from amzsear.core.AmzProduct import AmzProduct
 except ImportError:
-    from .amzsear.core import build_url
-    from .amzsear.core.consts import URL_ADDONS, SEARCH_URL, DEFAULT_REGION
-    from .amzsear.core.AmzProduct import AmzProduct
+    from . import build_url
+    from .consts import URL_ADDONS, SEARCH_URL, DEFAULT_REGION
+    from .AmzProduct import AmzProduct
 
 """
     The AmzSear object is similar to a Python dict, with each item having a
@@ -74,14 +74,24 @@ class AmzSear(object):
         if url != None:
             url = get_iter(url)
             self._urls = url
-            html = [request.urlopen(request.Request(build_url(u), **URL_ADDONS)).read() for u in url]
+            html = []
+            for u in url:
+                req = request.Request(
+                    build_url(u),
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0",
+                        "Accept-Language": "en-US,en;q=0.9",
+                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    }
+                )
+                html.append(request.urlopen(req).read())
         if html != None:
             html = get_iter(html)
             html_element = [html_module.fromstring(h) for h in html]
         if html_element != None:
             html_element = get_iter(html_element)
             for html_el in html_element:
-                products = html_el.cssselect('li[id*="result_"]')
+                products = html_el.cssselect('div[data-asin][data-component-type="s-search-result"]')
                 products = [x for x in products if x.cssselect('h2')]
                 products = [AmzProduct(elem) for elem in products]
         if products != None:

--- a/amzsear/core/__init__.py
+++ b/amzsear/core/__init__.py
@@ -71,6 +71,11 @@ def build_base_url(region=DEFAULT_REGION):
     return BASE_URL + REGION_CODES[find_region]
 
 
+class FetchError(Exception):
+    """Raised when fetching a URL fails."""
+    pass
+
+
 """
     Fetches HTML content from a URL and returns parsed lxml element.
 
@@ -78,7 +83,10 @@ def build_base_url(region=DEFAULT_REGION):
         url: The URL to fetch
 
     Returns:
-        lxml HTML element or None on failure
+        lxml HTML element
+
+    Raises:
+        FetchError: If the fetch fails (network error, 404, etc.)
 """
 def fetch_html(url):
     try:
@@ -86,5 +94,5 @@ def fetch_html(url):
         response = request.urlopen(req)
         html_content = response.read()
         return html_module.fromstring(html_content)
-    except Exception:
-        return None
+    except Exception as e:
+        raise FetchError(f"Failed to fetch {url}: {e}") from e

--- a/amzsear/core/__init__.py
+++ b/amzsear/core/__init__.py
@@ -1,11 +1,12 @@
-from urllib import parse
+from urllib import parse, request
+from lxml import html as html_module
 
 try:
     from amzsear.core.consts import (QUERY_BUILD_DICT, BASE_URL, DEFAULT_REGION,
-        REGION_CODES, SEARCH_URL)
+        REGION_CODES, SEARCH_URL, REQUEST_HEADERS)
 except ImportError:
-    from .amzsear.core.consts import (QUERY_BUILD_DICT, BASE_URL, DEFAULT_REGION,
-        REGION_CODES, SEARCH_URL)
+    from .consts import (QUERY_BUILD_DICT, BASE_URL, DEFAULT_REGION,
+        REGION_CODES, SEARCH_URL, REQUEST_HEADERS)
 
 
 """
@@ -68,3 +69,22 @@ def build_base_url(region=DEFAULT_REGION):
         raise ValueError('%s is not a know Amazon region' % (repr(region)))
 
     return BASE_URL + REGION_CODES[find_region]
+
+
+"""
+    Fetches HTML content from a URL and returns parsed lxml element.
+
+    Args:
+        url: The URL to fetch
+
+    Returns:
+        lxml HTML element or None on failure
+"""
+def fetch_html(url):
+    try:
+        req = request.Request(url, headers=REQUEST_HEADERS)
+        response = request.urlopen(req)
+        html_content = response.read()
+        return html_module.fromstring(html_content)
+    except Exception:
+        return None

--- a/amzsear/core/consts.py
+++ b/amzsear/core/consts.py
@@ -24,9 +24,6 @@ DEFAULT_REGION = "US"
 
 #URL Building
 BASE_URL = 'https://www.amazon'
-URL_ADDONS = {'headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) '
-                           'AppleWebKit/537.36 (KHTML, like Gecko) '
-                           'Chrome/60.0.3112.113 Safari/537.36'}}
 QUERY_BUILD_DICT = {}
 
 SEARCH_URL = '%s/s/ref=nb_sb_noss?sf=qz&keywords=%s&ie=UTF8&unfiltered=1&page=%s'
@@ -36,9 +33,9 @@ PRODUCT_URL = '%s/dp/%s'  # BASE_URL + region, ASIN
 REVIEWS_URL = '%s/product-reviews/%s'  # BASE_URL + region, ASIN
 QA_URL = '%s/ask/questions/asin/%s'  # BASE_URL + region, ASIN
 
-# Request headers for detail fetching (more complete browser-like headers)
+# Request headers for all Amazon requests
 # Note: Don't include Accept-Encoding to get uncompressed response
-DETAIL_HEADERS = {
+REQUEST_HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.9',

--- a/amzsear/core/consts.py
+++ b/amzsear/core/consts.py
@@ -4,6 +4,7 @@ REPR_MAX_LEN_DEFAULT = 90
 #URL CODES
 REGION_CODES = {
     'AU': '.com.au',
+    'AE': '.ae',
     'BR': '.com.br',
     'CA': '.ca',
     'CN': '.cn',

--- a/amzsear/core/consts.py
+++ b/amzsear/core/consts.py
@@ -27,7 +27,20 @@ BASE_URL = 'https://www.amazon'
 URL_ADDONS = {'headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) '
                            'AppleWebKit/537.36 (KHTML, like Gecko) '
                            'Chrome/60.0.3112.113 Safari/537.36'}}
-GAT_ID = 't' + 'ag'
-QUERY_BUILD_DICT = {GAT_ID : 'alhs-20'}
+QUERY_BUILD_DICT = {}
 
-SEARCH_URL = '%s/s/ref=nb_sb_noss?sf=qz&keywords=%s&ie=UTF8&unfiltered=1&page=%s' 
+SEARCH_URL = '%s/s/ref=nb_sb_noss?sf=qz&keywords=%s&ie=UTF8&unfiltered=1&page=%s'
+
+# Product detail page URLs
+PRODUCT_URL = '%s/dp/%s'  # BASE_URL + region, ASIN
+REVIEWS_URL = '%s/product-reviews/%s'  # BASE_URL + region, ASIN
+QA_URL = '%s/ask/questions/asin/%s'  # BASE_URL + region, ASIN
+
+# Request headers for detail fetching (more complete browser-like headers)
+# Note: Don't include Accept-Encoding to get uncompressed response
+DETAIL_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.9',
+    'Connection': 'keep-alive',
+}

--- a/amzsear/core/selectors.py
+++ b/amzsear/core/selectors.py
@@ -1,0 +1,58 @@
+"""
+CSS selectors for parsing Amazon product pages.
+These selectors work with lxml/cssselect on raw HTML - no JS execution needed.
+"""
+from enum import Enum
+
+
+class DetailLevel(Enum):
+    """
+    Detail levels for product information fetching.
+    Higher levels include all data from lower levels plus additional requests.
+    """
+    SEARCH = 0      # No extra request (current behavior from search results)
+    BASIC = 1       # Product page details (1 request)
+    REVIEWS = 2     # + Reviews page (1 additional request)
+    FULL = 3        # + Q&A page (1 additional request)
+
+
+# Product detail page selectors
+PRODUCT_TITLE = '#productTitle'
+BRAND_LINK = '#bylineInfo'
+FEATURE_BULLETS = '#feature-bullets ul li span'
+PRODUCT_DESCRIPTION = '#productDescription'
+PRODUCT_DESCRIPTION_ALT = '#productDescription_feature_div'
+
+# Technical details table
+TECH_DETAILS_TABLE = '#prodDetails table'
+TECH_DETAILS_ROWS = '#prodDetails table tr'
+PRODUCT_DETAILS_TABLE = '#productDetails_techSpec_section_1 tr'
+PRODUCT_DETAILS_TABLE_ALT = '#productDetails_detailBullets_sections1 tr'
+
+# Images
+IMAGE_GALLERY = '#altImages img'
+MAIN_IMAGE = '#landingImage'
+IMAGE_THUMB_LIST = '#imageBlock img'
+
+# Reviews on product page
+REVIEW_COUNT = '#acrCustomerReviewText'
+RATING_STARS = '#acrPopover'
+STAR_HISTOGRAM = '.a-histogram-row'
+CUSTOMER_REVIEWS_SUMMARY = '.cr-insights-widget'
+TOP_REVIEWS = '[data-hook="review"]'
+
+# Reviews page selectors
+REVIEW_ITEM = '[data-hook="review"]'
+REVIEW_TITLE = '[data-hook="review-title"]'
+REVIEW_RATING = '[data-hook="review-star-rating"]'
+REVIEW_DATE = '[data-hook="review-date"]'
+REVIEW_BODY = '[data-hook="review-body"]'
+REVIEW_AUTHOR = '.a-profile-name'
+REVIEW_VERIFIED = '[data-hook="avp-badge"]'
+REVIEW_HELPFUL = '[data-hook="helpful-vote-statement"]'
+REVIEW_IMAGES = '[data-hook="review-image-tile"]'
+
+# Q&A page selectors
+QA_QUESTION = '.a-fixed-left-grid'
+QA_QUESTION_TEXT = '.a-declarative'
+QA_ANSWER = '.a-spacing-base'

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -14,21 +14,22 @@ $ amzsear 'Harry Potter Books'
 The extended amzSear usage can be seen by typing `amzsear` without any additional arguments.
 
 ```
-usage: amzsear [-h] [-p PAGE] [-i ITEM]
-               [-r {AU,BR,CA,CN,DE,ES,FR,IN,IT,JP,MX,NL,SG,UK,US}] [-d]
+usage: amzsear [-h] [-P ASIN] [-p PAGE] [-i ITEM]
+               [-r {AU,BR,CA,CN,DE,ES,FR,IN,IT,JP,MX,NL,SG,UK,US}] [-b]
                [-o {short,verbose,quiet,csv,json}]
-               query
+               [query]
 ```
 
 ###### Args
 *query*: The query string to search Amazon.
 
 ###### Optional Args
-*-h, --help*: Display extended help & usage information.  
-*-p NUM, --page NUM*: The page number to be searched (defaults to 1).  
-*-i NUM, --item NUM*: The item index to be displayed (relative to the page). If no item is specified, the entire page's products will be displayed.  
-*-r STR, --region STR*: The amazon country/region to be searched (defaults to. For a list of countries to country code see the [region table](../regions.md).  
-*-d, --dont-open*: Stop the page from opening in the default browser.  
+*-h, --help*: Display extended help & usage information.
+*-P ASIN, --product ASIN*: Fetch product details by ASIN instead of searching.
+*-p NUM, --page NUM*: The page number to be searched (defaults to 1).
+*-i ITEM, --item ITEM*: Select item by ASIN or numeric index (0-based position). If no item is specified, the entire page's products will be displayed.
+*-r STR, --region STR*: The amazon country/region to be searched (defaults to US). For a list of countries to country code see the [region table](../regions.md).
+*-b, --browser*: Open the product page in the default browser.
 *-o STR, --output STR*: The output type to be displayed (defaults to short). Output types are as follows:
 * *short*: A concise view of the title, price summary and rating.
 * *verbose*: The complete amzSear representation taken from the core api representation.
@@ -74,13 +75,13 @@ In the above example, the first page of results for the query `Harry Potter` wil
 
 ###### Example 2
 ```
-$ amzsear 'Harry Potter' -i 20
+$ amzsear 'Harry Potter' -i 0
 
 	OR
 
-$ amzsear 'Harry Potter' --item 20
+$ amzsear 'Harry Potter' -i B00728DYLA
 ```
-This example will display the item at index 20 of page 1 (as page 1 is the default). If the index could not be found on page 1 an empty result will appear.
+This example will display the first item (index 0) or the item with ASIN B00728DYLA. The `-i` flag accepts both numeric index (0-based) and ASIN.
 
 ###### Example 3
 ```
@@ -94,13 +95,13 @@ Example 3 will display all results from the `Harry Potter` searching the Spanish
 
 ###### Example 4
 ```
-$ amzsear 'Harry Potter' -d
+$ amzsear 'Harry Potter' -b
 
 	OR
-    
-$ amzsear 'Harry Potter' --dont-open
+
+$ amzsear 'Harry Potter' --browser
 ```
-This example will produce the same output as it would without the `-d` option, however the page will not be opened in the default browser.
+This example will display the search results and open the product pages in the default browser. By default, the browser is not opened.
 
 ###### Example 5
 ```
@@ -114,9 +115,15 @@ In this example a csv of all products from the first page of search results is p
 
 ###### Example 6
 ```
-$ amzsear 'Harry Potter' -p 2 -i 35 --output json
+$ amzsear 'Harry Potter' -p 2 -i B00728DYLA --output json
 ```
-In this final example a JSON object of the item at index 35 on page 2 is displayed.
+In this example a JSON object of the item with ASIN B00728DYLA on page 2 is displayed.
+
+###### Example 7
+```
+$ amzsear -P B00006IFHD
+```
+This example fetches detailed product information directly by ASIN, bypassing search. Returns brand, title, specs, bullet points, and review statistics.
 
 
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -14,8 +14,8 @@ $ amzsear 'Harry Potter Books'
 The extended amzSear usage can be seen by typing `amzsear` without any additional arguments.
 
 ```
-usage: amzsear [-h] [-P ASIN] [-p PAGE] [-i ITEM]
-               [-r {AU,BR,CA,CN,DE,ES,FR,IN,IT,JP,MX,NL,SG,UK,US}] [-b]
+usage: amzsear [-h] [-a ASIN] [-p PAGE] [-s SELECT]
+               [-r {AU,AE,BR,CA,CN,DE,ES,FR,IN,IT,JP,MX,NL,SG,UK,US}] [-b]
                [-o {short,verbose,quiet,csv,json}]
                [query]
 ```
@@ -25,9 +25,9 @@ usage: amzsear [-h] [-P ASIN] [-p PAGE] [-i ITEM]
 
 ###### Optional Args
 *-h, --help*: Display extended help & usage information.
-*-P ASIN, --product ASIN*: Fetch product details by ASIN instead of searching.
+*-a ASIN, --asin ASIN*: Fetch product details by ASIN instead of searching.
 *-p NUM, --page NUM*: The page number to be searched (defaults to 1).
-*-i ITEM, --item ITEM*: Select item by ASIN or numeric index (0-based position). If no item is specified, the entire page's products will be displayed.
+*-s SELECT, --select SELECT*: Select result by ASIN or numeric index (0-based position). If no selection is specified, the entire page's products will be displayed.
 *-r STR, --region STR*: The amazon country/region to be searched (defaults to US). For a list of countries to country code see the [region table](../regions.md).
 *-b, --browser*: Open the product page in the default browser.
 *-o STR, --output STR*: The output type to be displayed (defaults to short). Output types are as follows:
@@ -75,13 +75,13 @@ In the above example, the first page of results for the query `Harry Potter` wil
 
 ###### Example 2
 ```
-$ amzsear 'Harry Potter' -i 0
+$ amzsear 'Harry Potter' -s 0
 
 	OR
 
-$ amzsear 'Harry Potter' -i B00728DYLA
+$ amzsear 'Harry Potter' -s B00728DYLA
 ```
-This example will display the first item (index 0) or the item with ASIN B00728DYLA. The `-i` flag accepts both numeric index (0-based) and ASIN.
+This example will display the first result (index 0) or the result with ASIN B00728DYLA. The `-s` flag accepts both numeric index (0-based) and ASIN.
 
 ###### Example 3
 ```
@@ -115,13 +115,13 @@ In this example a csv of all products from the first page of search results is p
 
 ###### Example 6
 ```
-$ amzsear 'Harry Potter' -p 2 -i B00728DYLA --output json
+$ amzsear 'Harry Potter' -p 2 -s B00728DYLA --output json
 ```
-In this example a JSON object of the item with ASIN B00728DYLA on page 2 is displayed.
+In this example a JSON object of the result with ASIN B00728DYLA on page 2 is displayed.
 
 ###### Example 7
 ```
-$ amzsear -P B00006IFHD
+$ amzsear -a B00006IFHD
 ```
 This example fetches detailed product information directly by ASIN, bypassing search. Returns brand, title, specs, bullet points, and review statistics.
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -16,7 +16,7 @@ The extended amzSear usage can be seen by typing `amzsear` without any additiona
 ```
 usage: amzsear [-h] [-a ASIN] [-p PAGE] [-s SELECT]
                [-r {AU,AE,BR,CA,CN,DE,ES,FR,IN,IT,JP,MX,NL,SG,UK,US}] [-b]
-               [-o {short,verbose,quiet,csv,json}]
+               [-v] [-j]
                [query]
 ```
 
@@ -30,35 +30,8 @@ usage: amzsear [-h] [-a ASIN] [-p PAGE] [-s SELECT]
 *-s SELECT, --select SELECT*: Select result by ASIN or numeric index (0-based position). If no selection is specified, the entire page's products will be displayed.
 *-r STR, --region STR*: The amazon country/region to be searched (defaults to US). For a list of countries to country code see the [region table](../regions.md).
 *-b, --browser*: Open the product page in the default browser.
-*-o STR, --output STR*: The output type to be displayed (defaults to short). Output types are as follows:
-* *short*: A concise view of the title, price summary and rating.
-* *verbose*: The complete amzSear representation taken from the core api representation.
-* *quiet*: No output is produced.
-* *csv*: A quoted csv of all products with with all fields flattened, including the index.
-* *json*: A JSON object of all products with all fields with the product's index as the top-level key.
-
-<a name="comparison-to-version-1"></a>
-##### Comparison to Version 1
-
-###### Verbose Argument
-In the previous version of amzSear, a verbose option could be displayed by adding the `-v` argument. However this can now be done through the output argument. For example:
-```
-$ amzsear 'Harry Potter' --output verbose
-
-	OR
-
-$ amzsear 'Harry Potter' -o verbose
-```
-
-###### Quiet Argument
-Similar to the verbose argument, a quiet option could be used in the previous version of amzSear by adding the `-q` argument. However this can now be done through the output argument. For example:
-```
-$ amzsear 'Harry Potter' --output quiet
-
-	OR
-
-$ amzsear 'Harry Potter' -o quiet
-```
+*-v, --verbose*: Show full product details instead of summary.
+*-j, --json*: Output in JSON format. Can be combined with -v for verbose JSON.
 
 <a name="examples"></a>
 ##### Examples
@@ -105,21 +78,11 @@ This example will display the search results and open the product pages in the d
 
 ###### Example 5
 ```
-$ amzsear 'Harry Potter' -o csv > harry_amzsear.csv
-
-	OR
-    
-$ amzsear 'Harry Potter' --output csv > harry_amzsear.csv
-```
-In this example a csv of all products from the first page of search results is produced and then piped into a csv called `harry_amzsear.csv`.
-
-###### Example 6
-```
-$ amzsear 'Harry Potter' -p 2 -s B00728DYLA --output json
+$ amzsear 'Harry Potter' -p 2 -s B00728DYLA -j
 ```
 In this example a JSON object of the result with ASIN B00728DYLA on page 2 is displayed.
 
-###### Example 7
+###### Example 6
 ```
 $ amzsear -a B00006IFHD
 ```

--- a/legacy/v1/amzsear/consts.py
+++ b/legacy/v1/amzsear/consts.py
@@ -1,7 +1,7 @@
 SITE_URL = 'https://www.amazon.com'
-BASE_URL = '%s/s/ref=sr_qz_back?sf=qz&keywords=%s&ie=UTF8&tag=alhsabc-20&unfiltered=1&page=%s' % (SITE_URL,'%s','%s')
-OUT_URL_TAG = '&tag=alhsabc-20'
-OUT_URL_REF = '/ref=as_li_tl?tag=alhsabc-20'
+BASE_URL = '%s/s/ref=sr_qz_back?sf=qz&keywords=%s&ie=UTF8&unfiltered=1&page=%s' % (SITE_URL,'%s','%s')
+OUT_URL_TAG = ''
+OUT_URL_REF = '/ref=sr_pg_1'
 URL_HEADERS = {'User-Agent' : 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36'}
 DEFAULT_PRICE_TEXT = "Base price"
 MAX_COL_SIZE = 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-lxml==3.8.0
+lxml>=4.9.1
+cssselect>=1.1.0
+lxml_html_clean>=0.1.0
+requests>=2.20.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='amzsear',
     packages=find_packages(),
-    version='3.0.0',
+    version='3.0.1',
     description='The unofficial Amazon search CLI & Python API',
     author="Asher Silvers",
     author_email="ashersilvers@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='amzsear',
     packages=find_packages(),
-    version='2.0.2',
+    version='3.0.0',
     description='The unofficial Amazon search CLI & Python API',
     author="Asher Silvers",
     author_email="ashersilvers@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
      ],
   },
   install_requires=[
-    'lxml==3.8',
+    "lxml>=4.9.1",
+    "cssselect>=1.1.0",
+    "lxml_html_clean>=0.1.0",
+    "requests>=2.20.0",
   ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,37 @@
 from setuptools import setup, find_packages
+
 setup(
-  name = 'amzsear',
-  packages = find_packages(),
-  version = '2.0.1',
-  description = 'The unofficial Amazon search CLI & Python API',
-  author = "Asher Silvers",
-  author_email = "ashersilvers@gmail.com",
-  license='MIT',
-  url = 'https://github.com/asherAgs/amzSear', 
-  keywords = 'amazon search product products python',
-  classifiers = [],
-  entry_points={
-    'console_scripts': [
-      'amzsear = amzsear.cli.cli:run',
-     ],
-  },
-  install_requires=[
-    "lxml>=4.9.1",
-    "cssselect>=1.1.0",
-    "lxml_html_clean>=0.1.0",
-    "requests>=2.20.0",
-  ],
+    name='amzsear',
+    packages=find_packages(),
+    version='2.0.2',
+    description='The unofficial Amazon search CLI & Python API',
+    author="Asher Silvers",
+    author_email="ashersilvers@gmail.com",
+    license='MIT',
+    url='https://github.com/asherAgs/amzSear',
+    keywords='amazon search product products python',
+    python_requires='>=3.7',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+    ],
+    entry_points={
+        'console_scripts': [
+            'amzsear = amzsear.cli.cli:run',
+        ],
+    },
+    install_requires=[
+        "lxml>=4.9.1",
+        "cssselect>=1.1.0",
+        "lxml_html_clean>=0.1.0",
+        "requests>=2.20.0",
+    ],
 )


### PR DESCRIPTION
## Summary

This fork brings amzSear up to date with modern Amazon and modern Python. It fixes broken search functionality, adds the ability to look up products by ASIN, and introduces new classes for fetching detailed product information and customer reviews.

**Note:** This PR is a superset of changes from [#35 by @Foadsf](https://github.com/asherAgs/amzSear/pull/35), which served as the starting point. On top of those fixes, this branch adds further updates, new features, and a refined CLI.

## What's New

### It Works Again
- **Updated selectors** to match Amazon's current HTML structure — search results now work reliably
- **Modernized HTTP layer** — switched from the deprecated `urllib` to `requests`, with proper headers and timeouts
- **Updated dependencies** to versions that work on current Python 3 installations
- **Fixed multi-page searches** — results from all pages are now collected properly

### New: Look Up Any Product by ASIN
You can now fetch detailed product information directly:

```bash
$ amzsear -a B00006IFHD
```

This returns the brand, full title, product bullet points, technical specifications, review count, average rating, and image URLs — all extracted from the product page.

### New: Customer Reviews
A new `AmzReviews` class lets you extract customer review data programmatically: reviewer name, star rating, review text, date, verified purchase status, helpful votes, and attached images.

### CLI Improvements
- **ASIN-based indexing** — search results are now keyed by the product's ASIN, making them stable and easy to reference
- **`-a/--asin`** — look up a product directly by ASIN
- **`-v/--verbose`** and **`-j/--json`** — simpler flags replace the old `--output` option
- **`-b/--browser`** — open the product page in your browser (replaces the inverted `--dont-open`)
- **`--version`** — see the installed version
- **Better error messages** — network failures and invalid keys now print clear errors with proper exit codes

### New Region Support
- Added **UAE (AE)** to the list of supported Amazon regions

### Under the Hood
- CSS selectors moved to a dedicated `selectors.py` file for easier maintenance
- All public methods now have proper docstrings
- Code follows PEP 8 style
- Products are deduplicated across multi-page searches
- Affiliate tracking tag removed from search queries

## Breaking Changes
- Product indices are now ASINs (10-character strings) instead of sequential numbers. Use `rget()` for positional access as before.
- `--output` is replaced by `-v` and `-j` flags; CSV export has been removed (use `-j` for JSON instead).
- `-i/--item` renamed to `-s/--select`.
- `-d/--dont-open` replaced by `-b/--browser` (inverted logic — now you opt in to opening the browser).